### PR TITLE
Use SQL parameterized queries to fix simple quote issue in book name

### DIFF
--- a/kobo_highlights/functions.py
+++ b/kobo_highlights/functions.py
@@ -144,13 +144,12 @@ def query_bookmarks_from_ereader(
 
         # Query string used on the "content" table.
         CONTENT_QUERY: str = (
-            f"SELECT Title, Attribution FROM content WHERE ContentID = '{volume_id}'"
-            " AND ContentType = '6' LIMIT 1;"
+            "SELECT Title, Attribution FROM content WHERE ContentID = ? AND ContentType = '6' LIMIT 1;"
         )
 
         # The same book can appear multiple times on the "content" table, but in order
         # to retrieve the data there's no need to query more than one result.
-        content_query_result: tuple = cursor_content.execute(CONTENT_QUERY).fetchone()
+        content_query_result: tuple = cursor_content.execute(CONTENT_QUERY, (volume_id,)).fetchone()
 
         current_bookmark["title"] = content_query_result[0]
 


### PR DESCRIPTION
It had an error when trying to import a bookmarks from a book that has a simple quote in its filename.

I fixed it using a parameterized SQL query.